### PR TITLE
Housekeeping: make it easier to generate a PDF of the constitution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@
 
 # PDF
 *.pdf
+
+# Committee list
+Roles.md

--- a/Declaration.md
+++ b/Declaration.md
@@ -1,12 +1,12 @@
 # HackSoc Committee Declaration
 
-*This template document is to be signed by all members of the incoming Committee before they take office. The signed Declaration should be made public on the HackSoc website by the incoming Committee once signed (the signed copy should not be committed here).*
+<!-- *This template document is to be signed by all members of the incoming Committee before they take office. The signed Declaration should be made public on the HackSoc website by the incoming Committee once signed (the signed copy should not be committed here).* -->
 
 As a Society Committee Member I agree to abide by, enforce, and operate in accordance with the HackSoc Constitution, YUSU's Constitution, YUSU's Policies, and guidelines in the Resource Hub.
 
 Signed by:
 
-*TO BE FILLED*
+<!-- *TO BE FILLED* -->
 
 - [name] -- Chair
 - [name] -- Secretary

--- a/Declaration.md
+++ b/Declaration.md
@@ -1,20 +1,7 @@
 # HackSoc Committee Declaration
 
-<!-- *This template document is to be signed by all members of the incoming Committee before they take office. The signed Declaration should be made public on the HackSoc website by the incoming Committee once signed (the signed copy should not be committed here).* -->
-
 As a Society Committee Member I agree to abide by, enforce, and operate in accordance with the HackSoc Constitution, YUSU's Constitution, YUSU's Policies, and guidelines in the Resource Hub.
 
 Signed by:
 
-<!-- *TO BE FILLED* -->
-
-- [name] -- Chair
-- [name] -- Secretary
-- [name] -- Treasurer
-- [name] -- Press & Publicity Officer
-- [name] -- Social Secretary
-- [name] -- Infrastructure Officer
-- [name] -- Academic Events Officer
-- [name] -- Ordinary Member
-- [name] -- Ordinary Member
-- [name] -- Ordinary Member
+<!-- see Roles.template.md -->

--- a/Declaration.md
+++ b/Declaration.md
@@ -7,3 +7,14 @@ As a Society Committee Member I agree to abide by, enforce, and operate in accor
 Signed by:
 
 *TO BE FILLED*
+
+- [name] -- Chair
+- [name] -- Secretary
+- [name] -- Treasurer
+- [name] -- Press & Publicity Officer
+- [name] -- Social Secretary
+- [name] -- Infrastructure Officer
+- [name] -- Academic Events Officer
+- [name] -- Ordinary Member
+- [name] -- Ordinary Member
+- [name] -- Ordinary Member

--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,2 @@
-Constitution.pdf: Constitution.md Declaration.md
+Constitution.pdf: Constitution.md Declaration.md Roles.md
 	pandoc -s $^ -o $@

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+Constitution.pdf: Constitution.md Declaration.md
+	pandoc -s $^ -o $@

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ The 'master' branch of this repository holds the canonical version of the HackSo
 
 The constitution is available in [Constitution.md](./Constitution.md).
 
+A PDF copy of the constitution and declaration can be produced by running `make` ([pandoc](https://pandoc.org/) is required). The declaration should be filled in with the approriate names, but not committed.
+
 This document outlines the procedure for changes to the constitution held in this repository. While it is not binding, it MUST be followed for consistency and continuity.
 
 ## 1. Definitions

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The 'master' branch of this repository holds the canonical version of the HackSo
 
 The constitution is available in [Constitution.md](./Constitution.md).
 
-A PDF copy of the constitution and declaration can be produced by running `make` (pdflatex and [pandoc](https://pandoc.org/) are required). The declaration should be filled in with the approriate names, but not committed.
+A PDF copy of the constitution and declaration can be produced by running `make` (pdflatex and [pandoc](https://pandoc.org/) are required). `Roles.md` should be created by copying `Roles.template.md`, filling in the names and removing the instructions, but should not be committed.
 
 This document outlines the procedure for changes to the constitution held in this repository. While it is not binding, it MUST be followed for consistency and continuity.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The 'master' branch of this repository holds the canonical version of the HackSo
 
 The constitution is available in [Constitution.md](./Constitution.md).
 
-A PDF copy of the constitution and declaration can be produced by running `make` ([pandoc](https://pandoc.org/) is required). The declaration should be filled in with the approriate names, but not committed.
+A PDF copy of the constitution and declaration can be produced by running `make` (pdflatex and [pandoc](https://pandoc.org/) are required). The declaration should be filled in with the approriate names, but not committed.
 
 This document outlines the procedure for changes to the constitution held in this repository. While it is not binding, it MUST be followed for consistency and continuity.
 

--- a/Roles.template.md
+++ b/Roles.template.md
@@ -1,0 +1,14 @@
+*This template document (see Declaration.md) is to be signed by all members of the incoming Committee before they take office. The signed Declaration should be made public on the HackSoc website by the incoming Committee once signed (the signed copy should not be committed here).*
+
+*TO BE FILLED*
+
+- [name] -- Chair
+- [name] -- Secretary
+- [name] -- Treasurer
+- [name] -- Press & Publicity Officer
+- [name] -- Social Secretary
+- [name] -- Infrastructure Officer
+- [name] -- Academic Events Officer
+- [name] -- Ordinary Member
+- [name] -- Ordinary Member
+- [name] -- Ordinary Member


### PR DESCRIPTION
A PDF copy of the constitution is useful to have in order to send to YUSU for reratification. It would be nice if producing that PDF was as simple as possible.

I'm not super happy about putting the instructions for filling in the declaration in comments; I'd like it if there was a way to make them show up on GitHub, but have Pandoc strip them out of the PDF.

I'm also not enthusiastic about having to modify *but not commit* `Declaration.md` in order to generate the PDF; possibly a way around that would be to move the actual bullet-point list of `[name] -- role` into a separate file, say `Roles.md.example`, then require that said file be copied to `Roles.md` and filled in to generate the PDF (which would have the benefit that `Roles.md` could be added to `.gitignore`).

Ideas/opinions welcome.