### PR TITLE
Amendment: Appendices

### DIFF
--- a/Constitution.md
+++ b/Constitution.md
@@ -6,7 +6,7 @@ This Constitution does not follow the default template laid out by YUSU, but doe
 
 ## Table of Contents
 
-1. [Definitions](#1-definitions)
+1. [This Document](#1-this-document)
 2. [Name of the Society](#2-name-of-the-society)
 3. [Aims and Objectives](#3-aims-and-objectives)
 4. [Membership](#4-membership)
@@ -22,10 +22,16 @@ This Constitution does not follow the default template laid out by YUSU, but doe
 14. [Amendments to the Society Constitution](#14-amendments-to-the-society-constitution)
 15. [Dissolution](#15-dissolution)
 
-## 1. Definitions
+## 1. This Document
 
-1. The society in this document will be referred to as the 'Society'.
-2. Those chosen to collectively represent the Society shall be referred to as the Committee.
+1. Definitions
+    1. The society in this document will be referred to as the 'Society'.
+    2. Those chosen to collectively represent the Society shall be referred to as the Committee.
+2. Appendices
+    1. This document may delegate specific and limited details of a clause to an appendix.
+    2. If an appendix is referenced in this document but does not yet exist, the Committee are responsible for creating it.
+    3. An appendix may be created or amended by a majority vote of the Committee.
+    4. Appendices that are not referenced in this document have no effect.
 
 ## 2. Name of the Society
 
@@ -174,8 +180,8 @@ This Constitution does not follow the default template laid out by YUSU, but doe
 4. Only paid-up Society members who are also full members of YUSU shall be entitled to vote.
 5. The Committee must be democratically elected in a free and fair election.
     1. All Society members must have the chance to question candidates and submit a vote in private and in absentia (where necessary).
-    2. Votes are counted using Single Transferable Vote.
-    3. if desired, YUSU can provide assistance in the running of any election to ensure fairness or to count votes where necessary.
+    2. Votes are counted using Single Transferable Vote, as specified in Appendix B.
+    3. If desired, YUSU can provide assistance in the running of any election to ensure fairness or to count votes where necessary.
 6. If any vacancies occur in the Committee during the academic year, they shall be democratically filled as soon as is convenient via an EGM (Extraordinary General Meeting).
 7. Members can stand jointly for election to any Committee position in teams of 2 individuals, under the following regulations:
     1. Both members must be paid-up Society members as per 10.1.
@@ -183,6 +189,7 @@ This Constitution does not follow the default template laid out by YUSU, but doe
     3. In committee-only votes, the members which hold a joint position shall only have one collective vote.
     4. If there is an irreconcilable disagreement between members holding a joint position in regards to a major decision related to their role, there shall be a committee vote in the next committee meeting. All present members shall be allowed to cast a vote on what action shall be taken in order to solve the disagreement and decide on the action to be taken.
 8. Before taking office, Society Committee members must sign a public declaration agreeing to abide by, enforce, and operate in accordance with this Constitution, YUSU's Constitution, YUSU's Policies, and guidelines in the Resource Hub.
+    1. The template for this declaration is given in Appendix A.
 
 ## 11. Society Complaints Procedure
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # The HackSoc Constitution
 
-The 'master' branch of this repository holds the canonical version of the HackSoc constitution.
+The 'master' branch of this repository holds the canonical version of the HackSoc constitution and its appendices.
 
-The constitution is available in [Constitution.md](./Constitution.md).
+The constitution is available in [Constitution.md](./Constitution.md) and appendices may be found in [appendices/](./appendices/).
 
 A PDF copy of the constitution and declaration can be produced by running `make` (pdflatex and [pandoc](https://pandoc.org/) are required). `Roles.md` should be created by copying `Roles.template.md`, filling in the names and removing the instructions, but should not be committed.
 
@@ -15,21 +15,38 @@ This document outlines the procedure for changes to the constitution held in thi
     1. HackSoc will be referred to as the 'Society'.
     2. The constitution of the Society, as laid out in [Constitution.md](./Constitution.md), will be referred to as the 'Constitution'.
 
-## 2. Changes to the Constitution
+## 2. General Rules
 
-1. All changes to the Constitution MUST be made via a Pull Request.
-2. Pull Requests for changes to the Constitution MUST be merged following a successful vote at a General Meeting of the Society.
-3. 'Housekeeping' changes MAY be made on the conditions that said changes:
-    1. MUST not affect the meaning of the Constitution (though they MAY affect the format and/or style);
-    2. MUST be made via a Pull Request as per 2.1, for which the following restrictions apply:
+1. All changes to this repository MUST be made via a Pull Request.
+2. 'Housekeeping' changes MAY be made on the conditions that said changes:
+    1. MUST NOT affect the meaning of the Constitution or its appendices (though they MAY affect the format and/or style);
+    2. MUST be made via a Pull Request as per §2.1, for which the following restrictions apply:
         1. The change's Pull Request MUST be clearly marked as housekeeping;
         2. The commit message for the change's Pull Request MUST start with the text 'Housekeeping:'.
-4. Pull Request MUST only be merged as set out by this section (2).
-5. Pull Requests SHOULD contain a summary of the discussion and debate of the proposed amendment they represent, if they represent one.
-6. Pull Requests MUST contain the results of any vote on the amendment they represent, if they represent one.
-7. The commit message for all Pull Requests, except those outlined in 2.4, MUST contain the results of the passing vote for the amendment they represent e.g. the number of votes for, against, and abstentions.
-8. Pull Requests MUST be merged as a single commit.
-9. The commit message for all merges of Pull Requests MUST contain a reference to the Pull Request they were merged from.
-10. Pull Requests MUST represent at most a single amendment to the Constitution.
-11. Changes to the Constitution SHOULD be proposed by the creation of a Pull Request for an amendment to be discussed and voted on at the next General Meeting of the Society.
-12. Ideas for changes to the Constitution MAY be proposed by the creation of an Issue, which MUST be refined into a specific change before it can be considered at a General Meeting.
+3. Pull Requests MUST only be merged as set out by this document.
+4. Pull Requests MUST be merged as a single commit.
+5. The commit message for all merges of Pull Requests MUST contain a reference to the Pull Request they were merged from.
+
+## 3. Changes to the Constitution
+
+1. Pull Requests for amendments to the Constitution:
+    1. MUST be merged following a successful vote at a General Meeting of the Society.
+    2. MUST contain the results of any vote on the amendment they represent.
+    3. SHOULD contain a summary of the discussion and debate of the proposed amendment they represent.
+    4. MUST represent exactly one amendment to the Constitution.
+2. Commit messages merging Pull Requests for amendments to the Constitution:
+    1. MUST contain the results of the passing vote for the amendment they represent (i.e. the number of votes for, against, and abstaining).
+    2. MUST start with the text 'Amendment:'.
+3. Changes to the Constitution SHOULD be proposed by the creation of a Pull Request for an amendment to be discussed and voted on at the next General Meeting of the Society.
+4. Ideas for changes to the Constitution MAY be proposed by the creation of an Issue, which MUST be refined into a specific change before it can be considered at a General Meeting.
+
+## 4. Changes to Constitutional Appendices
+
+1. Pull Requests for amendments to Constitutional Appendices:
+    1. MUST be merged following a successful vote at a meeting of the Committee.
+    2. MUST contain the result of any vote on the amendment they represent.
+    3. MUST represent an amendment to exactly one Appendix of the Constitution.
+    4. MUST not affect the content of the Constitution.
+2. Commit messages merging Pull Requests for amendments to Constitutional appendices:
+    1. MUST contain the results of the passing vote for the amendment they represent (i.e. the number of votes for, against, and abstaining)
+    2. MUST start with the text 'Appendix `X`:', where `X` is the letter of the affected appendix.


### PR DESCRIPTION
The Constitution regularly leaves out details on matters.

For example, §10.5.2 specifies that "Single Transferable Vote" should be used to count votes but STV is not a single method of counting votes. There are many variations that can produce significantly different results. As it stands, this is undefined and largely ends up being down to the Returning Officer to decide.

It makes sense for such specificities to be beyond the scope of the constitution. Such details are too important to leave to in-the-moment interterpretation while not important enough that they should require going to the lengths of organising a General Meeting and getting a two-thirds majority to amend. They can also be notably complex.

To fix this, I propose that we amend the constitution to allow "appendices". These constitutional appendicies should be required to be specified by the constitution and limited in scope, and they should be able to be amended by a simple majority of the committee. These measures would respectively prevent appendices from effectively being a backdoor to amending the constitution while maintaining reasonable democratic control over them.

As it stands, this pull request contains my initial proposal for what the amendment should be. This includes two places where I think appendices should be utilised: the definition of STV (text not yet provided) and the template for the committee declaration (which would basically be what we already have in [Declaration.md](https://github.com/HackSoc/constitution/blob/01312cc706027bf40d4c261ed89f18de2e9cf9ed/Declaration.md)).

This pull request also contains a suggested change to the rules for this repository to account for amendments to Constitutional Appendicies.

Comments, concerns, and suggestions are of course welcome.