### PR TITLE
Amendment: Add appendix for Code of Conduct

### DIFF
--- a/Constitution.md
+++ b/Constitution.md
@@ -67,9 +67,7 @@ This Constitution does not follow the default template laid out by YUSU, but doe
 11. Any action taken by the members on behalf of or while representing the Society in any way will also be accountable to the YUSU Code of Conduct found in By-Law 12.
 12. Breaches of this code of practice can result in Society, YUSU, or University disciplinary action.
 13. The Society must adhere to the GDPR in order to protect their members' data, they should make members aware of how their data will be used and be able to justify doing so.
-14. In addition:
-    1. Members must follow the code of conduct for use of Society chat systems (e.g. IRC, Slack, etc.);
-    2. Members making use of HackSoc-provided servers must follow any applicable acceptable use policies.
+14. In addition, all members must follow the HackSoc Code of Conduct, as set out in Appendix D.
 15. In addition to the Code of Practice laid out in this document, members of the committee are expected to abide by further policies as set out in Appendix C.
 16. The further policies set out in Appendix C should be periodically reviewed by the committee to ensure that it reflects the current common practice of the committee.
 

--- a/appendices/D-code-of-conduct.md
+++ b/appendices/D-code-of-conduct.md
@@ -1,6 +1,6 @@
 # Appendix D: Code of Conduct
 
-This appendix lays out the code of conduct that all HackSoc Members must adhere by. This code of conduct can also be found on the HackSoc [Website](https://www.hacksoc.org/coc.html), which also details some conventions used in HackSoc spaces.
+This appendix lays out the code of conduct that all HackSoc members must adhere by. This code of conduct can also be found on the HackSoc [website](https://www.hacksoc.org/coc.html), which also details some conventions used in HackSoc spaces.
 
 ## Values Statement
 

--- a/appendices/D-code-of-conduct.md
+++ b/appendices/D-code-of-conduct.md
@@ -1,0 +1,46 @@
+# Appendix D: Code of Conduct
+
+This appendix lays out the code of conduct that all HackSoc Members must adhere by. This code of conduct can also be found on the HackSoc [Website](https://www.hacksoc.org/coc.html), which also details some conventions used in HackSoc spaces.
+
+## Values Statement
+
+HackSoc aims to be an inclusive space for all, and this code of conduct aims to reflect that. We are not able to cover every single behaviour in this code of conduct, so do not take it as a bullet pointed list of what you can and cannot do. Please follow the spirit of this code as well as the letter.
+
+If you see behaviour that is unacceptable and the person committing it doesn’t stop when asked, please reach out to a committee member, either in a channel or privately. (Your confidentiality will be respected if you reach out privately.)
+
+We will not tolerate any use of this code of conduct as a hammer against marginalised people speaking out against harassment or microaggressions, or enforcing reasonable boundaries.
+
+## Rules
+
+### General
+
+* No sexism, racism, ableism, queerphobia, xenophobia, casteism, antisemitism or discrimination of any kind
+* No advocating, even in jest, for Nazis/white supremacy etc
+* Be wary of “dog whistles”, or innocuous-seeming words or images that have another meaning to a specific audience (the [Anti-Defamation League](https://www.adl.org/hate-symbols) has a list of (mainly white supremacist) hate symbols which may be used as dog whistles)
+* Avoid making fun of other people’s spelling, word choices, phrasing etc. – if you’re making a joke, think for a few seconds about why it’s funny first
+* Committee may ask you to stop any behaviour that is not explicitly disallowed here
+* No harassment: if someone asks you to stop interacting with them, do not use our spaces to circumvent this
+* This Code of Conduct applies to all HackSoc spaces, online or physical, public or private
+* As a YUSU society, our members are also bound by the [YUSU Code of Conduct](https://yusu.org/about-us/documents/by-laws)
+
+### Chat Platforms
+
+* No spam
+    * e.g. using excessive numbers of animated emoji
+* Bots are welcome, so long as they don’t produce spam
+* Follow the content requirements of those who host us
+* You may be asked to stop a conversation by committee
+* Committee reserve the right to remove messages if they are in violation of the codes of conduct and you have been asked to stop by a committee member
+* Committee reserve the right to kick humans or bots at any time
+* Committee reserve the right to delete channels
+* Committee reserves the right to delete any content
+    * e.g. NSFW content
+
+### GitHub
+
+* Not everyone is at the same level. Do not mock, humiliate, or insult someone over the contents of a pull request.
+* Issues, pull requests, and the contents of files pushed to HackSoc repositories are all covered by this Code of Conduct
+
+### Our Servers
+
+Our servers are hosted by various third parties (including Bytemark and the University of York) – please use them in accordance with the acceptable use policy associated with the relevant host.


### PR DESCRIPTION
Adds the code of conduct appendix, as mentioned in issue #15. The code of conduct can also be found at [hacksoc.org/coc.html](https://www.hacksoc.org/coc.html).

Several notes, as this is not yet ready:

- I named the appendix D, even though it is the first appendix to appear, as the order of appearance and the alphabetical order of appendices is not otherwise reflected in this document. Happy to change that however, although it would probably need to be a different Housekeeping PR
- So far, I've only replaced point 14 with the code of conduct, as it is the one that references the previous code of conduct in irc.html. However, there may be some overlap between the new code of conduct and other points in this section (which I believe is directly pulled from YUSU). Does anyone have opinions on whether we should have the redundancy or change it?
- Similarly, our CoC references YUSU's. The section in our constitution that references Appendix D is lifted from the YUSU CoC. Are we ok with a circular dependency?
- I did not add the conventions and guidelines, instead simply referencing them, as Appendices need a full committee vote to change them, and things like "Oh we discovered that sowing now no longer bridges thread replies to channel if there are more than 5 replies in a thread" would probably be added to the conventions, but not need a committee vote. But, if anyone has objections/further thoughts, I am happy to change this. 