### PR TITLE
Renaming committee positions

### DIFF
--- a/Constitution.md
+++ b/Constitution.md
@@ -82,10 +82,10 @@ This Constitution does not follow the default template laid out by YUSU, but doe
     2. Secretary
     3. Treasurer
     4. Press & Publicity Officer
-    5. Social Secretary
+    5. Social Events Officer
     6. Infrastructure Officer
     7. Academic Events Officer
-    8. 3 × Ordinary Members
+    8. 3 × Ordinary Officers
 6. The Committee will ensure an up-to-date list of Committee members is provided to YUSU within two working days of any election.
 
 ## 7. Duties of the Society's Committee
@@ -112,7 +112,7 @@ This Constitution does not follow the default template laid out by YUSU, but doe
     7. Calling and chairing meetings of the Society's committee.
     8. Publicising the Society.
     9. Any other duties as mutually agreed by the Committee and the Chair.
-2. The Society Secretary is responsible for:
+2. The Secretary is responsible for:
     1. Attending society officer training.
     2. Taking care of society administration and updating the Society's backpages information and membership list.
     3. Arranging meetings and booking rooms or venues.
@@ -140,7 +140,7 @@ This Constitution does not follow the default template laid out by YUSU, but doe
         2. Manage the Society's social media accounts.
         3. Advertise the events of the Society.
         4. Conduct outreach on behalf of the Society.
-    2. Social Secretary:
+    2. Social Events Officer:
         1. Responsible for non-academic events.
         2. Aid members of the society in the organisation of social events.
         3. Work with the Secretary to organise events.
@@ -150,7 +150,7 @@ This Constitution does not follow the default template laid out by YUSU, but doe
         3. Work with the Secretary to organise events.
     4. Infrastructure Officer
         1. Manage the technical infrastructure of the Society, including servers, backend of the website, and Society chat systems.
-    5. Ordinary Members
+    5. Ordinary Officers
         1. Responsibilities will be allocated as required.
 5. No Committee member should be responsible for case work e.g. giving support and advice to any individual student. If and when these cases present they must be referred promptly to the student opportunities coordinator who can ensure the proper support is made available.
 

--- a/Roles.template.md
+++ b/Roles.template.md
@@ -6,9 +6,9 @@
 - [name] -- Secretary
 - [name] -- Treasurer
 - [name] -- Press & Publicity Officer
-- [name] -- Social Secretary
+- [name] -- Social Events Officer
 - [name] -- Infrastructure Officer
 - [name] -- Academic Events Officer
-- [name] -- Ordinary Member
-- [name] -- Ordinary Member
-- [name] -- Ordinary Member
+- [name] -- Ordinary Officer
+- [name] -- Ordinary Officer
+- [name] -- Ordinary Officer


### PR DESCRIPTION
This amendment seeks to reduce the confusion between the Secretary and Social Secretary roles, as well as Ordinary Members, by:
- Removing the reference to the 'Society Secretary' in section 7.2 and replacing it with 'Secretary', like the other signatory roles within that section;
- Renaming Social Secretary to Social Events Officer, to bring it in line with other non signatory positions such as Academic Events Officer;
- Renaming Ordinary Member to Ordinary Officer, to bring it in line with other non signatory positions.

Currently, it could be assumed that the Secretary and the Social Secretary were somehow linked, or the two could be easily confused. For Ordinary Members, it could potentially be confusing whether someone was referring to an Ordinary Member, or a member of the society that did not hold a place on the committee.