### PR TITLE
Appendix D: Update CoC for Discord migration

### DIFF
--- a/appendices/D-code-of-conduct.md
+++ b/appendices/D-code-of-conduct.md
@@ -39,6 +39,8 @@ We will not tolerate any use of this code of conduct as a hammer against margina
 * Committee reserves the right to delete any content
     * e.g. NSFW content
 
+On our chat platforms, this code of conduct applies both to messages and to other information that is visible to our users. This includes profiles and statuses.
+
 ### GitHub
 
 * Not everyone is at the same level. Do not mock, humiliate, or insult someone over the contents of a pull request.


### PR DESCRIPTION
The Code of Conduct should explicitly state that it covers all information visible in our chat platforms, not just messages. This is particularly pertinent to Discord, where profiles and statuses are not necessarily specific to our server but should still conform to our CoC.