### PR TITLE
Proposal: remove requirement for email updates

### DIFF
--- a/Constitution.md
+++ b/Constitution.md
@@ -138,7 +138,7 @@ This Constitution does not follow the default template laid out by YUSU, but doe
     9. Creating a budget for each event.
 4. Duties of other committee members:
     1. Press & Publicity Officer:
-        1. Send weekly update emails.
+        1. Send weekly updates, either through email or another method that reaches all Society members.
         2. Manage the Society's social media accounts.
         3. Advertise the events of the Society.
         4. Conduct outreach on behalf of the Society.


### PR DESCRIPTION
Currently weekly updates MUST be sent as emails, although in some cases sending the updates via e.g. a Discord channel may be preferred if it can reach all Society members.  This pull request removes the requirement for the update to be sent via email.